### PR TITLE
Upper/lower casing in PyMC reference

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -74,7 +74,7 @@ archivePrefix = {arXiv},
 }
 
 @article{pymc2023,
-  title={PyMC: A Modern and Comprehensive Probabilistic Programming Framework in Python},
+  title={{PyMC}: A Modern and Comprehensive Probabilistic Programming Framework in {Python}},
   author={Abril-Pla Oriol and Andreani Virgile and Carroll Colin and Dong Larry and Fonnesbeck Christopher J. and Kochurov Maxim and Kumar Ravin and Lao Jupeng and Luhmann Christian C. and Martin Osvaldo A. and Osthege Michael and Vieira Ricardo and Wiecki Thomas and Zinkov Robert},
   journal = {{PeerJ} Computer Science},
   publisher = {{PeerJ}},


### PR DESCRIPTION
One final tweak ahead of JOSS publication (see [review](https://github.com/openjournals/joss-reviews/issues/7201)). Sorry for missing this until now!