### PR TITLE
Update install instructions with pinned arviz fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Install with `pip` in a `conda` virtual environment:
 ```
 conda create --name bayes_spec -c conda-forge pymc pip
 conda activate bayes_spec
+# Due to a bug in arviz, this fork is temporarily necessary
+# See: https://github.com/arviz-devs/arviz/issues/2437
+pip install git+https://github.com/tvwenger/arviz.git@plot_pair_reference_labels
 pip install bayes_spec
 ```
 

--- a/bayes_spec/plots.py
+++ b/bayes_spec/plots.py
@@ -11,8 +11,6 @@ from typing import Optional, Iterable
 
 import arviz as az
 import arviz.labels as azl
-from arviz.sel_utils import xarray_var_iter
-from arviz.utils import get_coords
 
 from matplotlib.axes import Axes
 import matplotlib.pyplot as plt

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,9 @@ Installation
     
     conda create --name bayes_spec -c conda-forge pymc pip
     conda activate bayes_spec
+    # Due to a bug in arviz, this fork is temporarily necessary
+    # See: https://github.com/arviz-devs/arviz/issues/2437
+    pip install git+https://github.com/tvwenger/arviz.git@plot_pair_reference_labels
     pip install bayes_spec
 
 .. toctree::

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pymc>=5
 pytensor
 nutpie
 numba
-# arviz
+arviz
 matplotlib
 scipy
 scikit-learn
@@ -15,4 +15,3 @@ jaxlib
 jax
 blackjax
 numpyro
-arviz @ git+https://github.com/tvwenger/arviz.git@plot_pair_reference_labels


### PR DESCRIPTION
Since we need to use a pinned `arviz` version (see https://github.com/arviz-devs/arviz/issues/2437), this PR updates the installation instructions as necessary. It also removes the fork from `requirements.txt` so that we can upload to PyPI.